### PR TITLE
Get dependencies from rosdep instead of building from source.

### DIFF
--- a/cloudwatch_metrics_collector/package.xml
+++ b/cloudwatch_metrics_collector/package.xml
@@ -13,20 +13,20 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
-  <build_depend>ros_monitoring_msgs</build_depend>
-  <build_depend>cloudwatch_metrics_common</build_depend>
+  <build_depend version_lt='2.0.0'>ros_monitoring_msgs</build_depend>
+  <build_depend version_lt='2.0.0'>cloudwatch_metrics_common</build_depend>
   <build_depend>roscpp</build_depend>
-  <build_depend>aws_common</build_depend>
-  <build_depend>aws_ros1_common</build_depend>
+  <build_depend version_lt='2.0.0'>aws_common</build_depend>
+  <build_depend version_lt='2.0.0'>aws_ros1_common</build_depend>
 
   <build_export_depend>roscpp</build_export_depend>
-  <build_export_depend>cloudwatch_metrics_common</build_export_depend>
-  <build_export_depend>ros_monitoring_msgs</build_export_depend>
-  <build_export_depend>aws_ros1_common</build_export_depend>
+  <build_export_depend version_lt='2.0.0'>cloudwatch_metrics_common</build_export_depend>
+  <build_export_depend version_lt='2.0.0'>ros_monitoring_msgs</build_export_depend>
+  <build_export_depend version_lt='2.0.0'>aws_ros1_common</build_export_depend>
 
-  <exec_depend>aws_ros1_common</exec_depend>
-  <exec_depend>ros_monitoring_msgs</exec_depend>
-  <exec_depend>cloudwatch_metrics_common</exec_depend>
+  <exec_depend version_lt='2.0.0'>aws_ros1_common</exec_depend>
+  <exec_depend version_lt='2.0.0'>ros_monitoring_msgs</exec_depend>
+  <exec_depend version_lt='2.0.0'>cloudwatch_metrics_common</exec_depend>
   <exec_depend>roscpp</exec_depend>
   
   <test_depend>rostest</test_depend>


### PR DESCRIPTION
The release branch of cloud extension packages should take dependencies from rosdep(apt) instead of building from source.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
