### PR TITLE
use master branch for cloud extension dependencies

### DIFF
--- a/.rosinstall.master
+++ b/.rosinstall.master
@@ -1,0 +1,12 @@
+- git:
+    uri: https://github.com/aws-robotics/utils-common.git
+    local-name: utils-common
+    version: master
+- git:
+    uri: https://github.com/aws-robotics/utils-ros1.git
+    local-name: utils-ros1
+    version: master
+- git:
+    uri: https://github.com/aws-robotics/cloudwatch-common.git
+    local-name: cloudwatch-common
+    version: master

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,19 +8,18 @@ notifications:
     on_failure: always
     recipients:
       - ros-contributions@amazon.com
-      - travis-build@platform-notifications.robomaker.aws.a2z.com 
+      - travis-build@platform-notifications.robomaker.aws.a2z.com
 env:
+  global:
+    - UPSTREAM_WORKSPACE=file
+    - ROSINSTALL_FILENAME=.rosinstall.master
   matrix:
     - ROS_DISTRO="kinetic" ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu
     - ROS_DISTRO="kinetic" ROS_REPOSITORY_PATH=http://packages.ros.org/ros-shadow-fixed/ubuntu
-    - ROS_DISTRO="lunar"   ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu
-    - ROS_DISTRO="lunar"   ROS_REPOSITORY_PATH=http://packages.ros.org/ros-shadow-fixed/ubuntu
     - ROS_DISTRO="melodic" ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu
     - ROS_DISTRO="melodic" ROS_REPOSITORY_PATH=http://packages.ros.org/ros-shadow-fixed/ubuntu
 matrix:
   allow_failures:
-    - env: ROS_DISTRO="lunar"   ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu
-    - env: ROS_DISTRO="lunar"   ROS_REPOSITORY_PATH=http://packages.ros.org/ros-shadow-fixed/ubuntu
     - env: ROS_DISTRO="melodic" ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu
     - env: ROS_DISTRO="melodic" ROS_REPOSITORY_PATH=http://packages.ros.org/ros-shadow-fixed/ubuntu
 install:


### PR DESCRIPTION
*Description of changes:*

Properly implementing the "master" Travis build pipeline, where dependencies should come from HEAD instead of release tags or released binaries.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.