### PR TITLE
Update to use non-legacy ParameterReader API

### DIFF
--- a/cloudwatch_metrics_collector/package.xml
+++ b/cloudwatch_metrics_collector/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>cloudwatch_metrics_collector</name>
-  <version>1.0.0</version>
+  <version>2.0.0</version>
   <description>Subscriber node for the aws/monitoring topic to publish metrics to AWS Cloudwatch</description>
   <url>http://wiki.ros.org/cloudwatch_metrics_collector</url>
 

--- a/cloudwatch_metrics_collector/src/cloudwatch_metrics_collector.cpp
+++ b/cloudwatch_metrics_collector/src/cloudwatch_metrics_collector.cpp
@@ -37,8 +37,11 @@
 
 using namespace Aws::Client;
 using namespace Aws::Utils::Logging;
-using namespace Aws::CloudWatch::Metrics;
 
+
+namespace Aws {
+namespace CloudWatch {
+namespace Metrics {
 
 const std::string MetricsCollector::kNodeParamMonitorTopicsListKey = "aws_monitored_metric_topics";
 const std::string MetricsCollector::kNodeParamMetricNamespaceKey = "aws_metrics_namespace";
@@ -211,17 +214,23 @@ Aws::AwsError MetricsCollector::Initialize(ros::NodeHandle & nh)
   return status;
 }
 
+}  // namespace Metrics
+}  // namespace CloudWatch
+}  // namespace Aws
+
+
 int main(int argc, char * argv[])
 {
-  ros::init(argc, argv, MetricsCollector::kNodeName);
+  ros::init(argc, argv, Aws::CloudWatch::Metrics::MetricsCollector::kNodeName);
 
   ros::NodeHandle nh;
 
-  Aws::Utils::Logging::InitializeAWSLogging(
-    Aws::MakeShared<Aws::Utils::Logging::AWSROSLogger>(MetricsCollector::kNodeName.c_str()));
+  Aws::Utils::Logging::InitializeAWSLogging(Aws::MakeShared<Aws::Utils::Logging::AWSROSLogger>(
+    Aws::CloudWatch::Metrics::MetricsCollector::kNodeName.c_str()));
   Aws::AwsError status;
 
-  MetricsCollector metrics_collector = MetricsCollector::Build(status);
+  Aws::CloudWatch::Metrics::MetricsCollector metrics_collector
+    = Aws::CloudWatch::Metrics::MetricsCollector::Build(status);
   if (Aws::AWS_ERR_OK == status) {
     status = metrics_collector.Initialize(nh);
   }


### PR DESCRIPTION
*Description of changes:*

We have decided to remove the legacy portions of the ParameterReader API. ParameterReader will now only accept ParameterPath objects for addressing parameters. Calls to ReadParam need to be updated.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
