### PR TITLE
Rely on rostest_add_gmock instead of building GMock

### DIFF
--- a/cloudwatch_metrics_collector/CMakeLists.txt
+++ b/cloudwatch_metrics_collector/CMakeLists.txt
@@ -60,14 +60,11 @@ install(DIRECTORY
 ## Add gtest based cpp test target and link libraries
 if(CATKIN_ENABLE_TESTING)
   find_package(rostest REQUIRED)
-  include_directories(/usr/include/gmock /usr/src/gmock)
-  add_library(libgmock /usr/src/gmock/src/gmock-all.cc)
-
   SET(CW_METRICS_COLLECTOR_TEST test_cloudwatch_metrics_collector)
-  add_rostest_gtest(${CW_METRICS_COLLECTOR_TEST}
+  add_rostest_gmock(${CW_METRICS_COLLECTOR_TEST}
     test/test_cloudwatch_metrics_collector.test
     test/cloudwatch_metrics_collector_test.cpp)
   target_include_directories(${CW_METRICS_COLLECTOR_TEST} PRIVATE include ${catkin_INCLUDE_DIRS}
     ${cloudwatch_metrics_collector_INCLUDE_DIRS})
-  target_link_libraries(${CW_METRICS_COLLECTOR_TEST} ${PROJECT_NAME}_lib libgmock ${catkin_LIBRARIES})
+  target_link_libraries(${CW_METRICS_COLLECTOR_TEST} ${PROJECT_NAME}_lib ${catkin_LIBRARIES})
 endif()


### PR DESCRIPTION
Having statements like `add_library(libgmock ...)` increases the chances of conflicts with other projects. Specifically, right now, `cloudwatchmetrics-ros1` cannot be built in the same workspace as `cloudwatchlogs-ros1`. Using add_rostest_gmock is the proper way to utilize GMock in ROS packages.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
