### PR TITLE
fix broken build when cmake/rostest cannot find the gmock library

### DIFF
--- a/cloudwatch_metrics_collector/CMakeLists.txt
+++ b/cloudwatch_metrics_collector/CMakeLists.txt
@@ -59,12 +59,33 @@ install(DIRECTORY
 
 ## Add gtest based cpp test target and link libraries
 if(CATKIN_ENABLE_TESTING)
+  set(CW_METRICS_COLLECTOR_TEST test_cloudwatch_metrics_collector)
   find_package(rostest REQUIRED)
-  SET(CW_METRICS_COLLECTOR_TEST test_cloudwatch_metrics_collector)
-  add_rostest_gmock(${CW_METRICS_COLLECTOR_TEST}
-    test/test_cloudwatch_metrics_collector.test
-    test/cloudwatch_metrics_collector_test.cpp)
-  target_include_directories(${CW_METRICS_COLLECTOR_TEST} PRIVATE include ${catkin_INCLUDE_DIRS}
-    ${cloudwatch_metrics_collector_INCLUDE_DIRS})
-  target_link_libraries(${CW_METRICS_COLLECTOR_TEST} ${PROJECT_NAME}_lib ${catkin_LIBRARIES})
+  find_package(GMock QUIET)
+  if(GMOCK_FOUND)
+    add_rostest_gmock(${CW_METRICS_COLLECTOR_TEST}
+      test/test_cloudwatch_metrics_collector.test
+      test/cloudwatch_metrics_collector_test.cpp
+    )
+    target_include_directories(${CW_METRICS_COLLECTOR_TEST} PRIVATE
+      include
+      ${catkin_INCLUDE_DIRS}
+      ${cloudwatch_metrics_collector_INCLUDE_DIRS}
+      ${GMOCK_INCLUDE_DIRS}
+    )
+    target_link_libraries(${CW_METRICS_COLLECTOR_TEST} ${PROJECT_NAME}_lib ${catkin_LIBRARIES} ${GMOCK_BOTH_LIBRARIES})
+  else()
+    include_directories(/usr/include/gmock /usr/src/gmock)
+    add_library(${PROJECT_NAME}_libgmock /usr/src/gmock/src/gmock-all.cc)
+    add_rostest_gtest(${CW_METRICS_COLLECTOR_TEST}
+      test/test_cloudwatch_metrics_collector.test
+      test/cloudwatch_metrics_collector_test.cpp
+    )
+    target_include_directories(${CW_METRICS_COLLECTOR_TEST} PRIVATE
+      include
+      ${catkin_INCLUDE_DIRS}
+      ${cloudwatch_metrics_collector_INCLUDE_DIRS}
+    )   
+    target_link_libraries(${CW_METRICS_COLLECTOR_TEST} ${PROJECT_NAME}_lib ${catkin_LIBRARIES} ${PROJECT_NAME}_libgmock)
+  endif()
 endif()


### PR DESCRIPTION
*Description of changes:*

Mimic the way the `CMakeLists.txt` is written at https://github.com/aws-robotics/health-metrics-collector-ros1/blob/master/health_metric_collector/CMakeLists.txt#L66.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
