### PR TITLE
Fix linting issues found by clang-tidy 6.0

### DIFF
--- a/cloudwatch_metrics_collector/include/cloudwatch_metrics_collector/metrics_collector.hpp
+++ b/cloudwatch_metrics_collector/include/cloudwatch_metrics_collector/metrics_collector.hpp
@@ -37,7 +37,7 @@ class MetricsCollector : public Service
 public:
 
   MetricsCollector() = default;
-  ~MetricsCollector() = default;
+  ~MetricsCollector() override = default;
 
   /**
    * Accept input metric message to be batched for publishing.
@@ -65,11 +65,11 @@ public:
   void Initialize(std::string metric_namespace,
                   std::map<std::string, std::string> & default_dimensions,
                   int storage_resolution,
-                  ros::NodeHandle node_handle,
+                  const ros::NodeHandle& node_handle,
                   const Aws::Client::ClientConfiguration & config,
                   const Aws::SDKOptions & sdk_options,
                   const Aws::CloudWatchMetrics::CloudWatchOptions & cloudwatch_options,
-                  std::shared_ptr<MetricServiceFactory> metric_service_factory = std::make_shared<MetricServiceFactory>());
+                  const std::shared_ptr<MetricServiceFactory>& metric_service_factory = std::make_shared<MetricServiceFactory>());
 
   void SubscribeAllTopics();
 
@@ -94,7 +94,7 @@ private:
 
   std::string metric_namespace_;
   std::map<std::string, std::string> default_dimensions_;
-  std::atomic<int> storage_resolution_;
+  std::atomic<int> storage_resolution_{};
   std::shared_ptr<MetricService> metric_service_;
   std::vector<ros::Subscriber> subscriptions_;
   ros::NodeHandle node_handle_;

--- a/cloudwatch_metrics_collector/include/cloudwatch_metrics_collector/metrics_collector_parameter_helper.hpp
+++ b/cloudwatch_metrics_collector/include/cloudwatch_metrics_collector/metrics_collector_parameter_helper.hpp
@@ -22,7 +22,6 @@
 #include <unordered_set>
 #include <iostream>
 
-using namespace Aws::Client;
 
 namespace Aws {
 namespace CloudWatchMetrics {

--- a/cloudwatch_metrics_collector/include/cloudwatch_metrics_collector/metrics_collector_parameter_helper.hpp
+++ b/cloudwatch_metrics_collector/include/cloudwatch_metrics_collector/metrics_collector_parameter_helper.hpp
@@ -67,7 +67,7 @@ const std::set<int> kNodeParamMetricDatumStorageResolutionValidValues = {1, 60};
  * as returned by \p parameter_reader
  */
 void ReadPublishFrequency(
-        std::shared_ptr<Aws::Client::ParameterReaderInterface> parameter_reader,
+        const std::shared_ptr<Aws::Client::ParameterReaderInterface>& parameter_reader,
         double & publish_frequency);
 
 /**
@@ -77,7 +77,7 @@ void ReadPublishFrequency(
  * @return
  */
 void ReadMetricNamespace(
-        std::shared_ptr<Aws::Client::ParameterReaderInterface> parameter_reader,
+        const std::shared_ptr<Aws::Client::ParameterReaderInterface>& parameter_reader,
         std::string & metric_namespace);
 
 /**
@@ -88,7 +88,7 @@ void ReadMetricNamespace(
  * @return
  */
 void ReadMetricDimensions(
-        std::shared_ptr<Aws::Client::ParameterReaderInterface> parameter_reader,
+        const std::shared_ptr<Aws::Client::ParameterReaderInterface>& parameter_reader,
         Aws::String & dimensions_param,
         std::map<std::string, std::string> & metric_dims);
 /**
@@ -98,7 +98,7 @@ void ReadMetricDimensions(
  * @return
  */
 void ReadStorageResolution(
-        std::shared_ptr<Aws::Client::ParameterReaderInterface> parameter_reader,
+        const std::shared_ptr<Aws::Client::ParameterReaderInterface>& parameter_reader,
         int & storage_resolution);
 
 void ReadTopics(std::vector<std::string> & topics);
@@ -112,7 +112,7 @@ void ReadTopics(std::vector<std::string> & topics);
  * as returned by \p parameter_reader
  */
 void ReadCloudWatchOptions(
-  std::shared_ptr<Aws::Client::ParameterReaderInterface> parameter_reader,
+  const std::shared_ptr<Aws::Client::ParameterReaderInterface>& parameter_reader,
   Aws::CloudWatchMetrics::CloudWatchOptions & cloudwatch_options);
 
 /**
@@ -124,7 +124,7 @@ void ReadCloudWatchOptions(
  * as returned by \p parameter_reader
  */
 void ReadUploaderOptions(
-  std::shared_ptr<Aws::Client::ParameterReaderInterface> parameter_reader,
+  const std::shared_ptr<Aws::Client::ParameterReaderInterface>& parameter_reader,
   Aws::DataFlow::UploaderOptions & uploader_options);
 
 /**
@@ -136,7 +136,7 @@ void ReadUploaderOptions(
  * as returned by \p parameter_reader
  */
 void ReadFileManagerStrategyOptions(
-  std::shared_ptr<Aws::Client::ParameterReaderInterface> parameter_reader,
+  const std::shared_ptr<Aws::Client::ParameterReaderInterface>& parameter_reader,
   Aws::FileManagement::FileManagerStrategyOptions & file_manager_strategy_options);
 
 /**
@@ -150,7 +150,7 @@ void ReadFileManagerStrategyOptions(
  * as returned by \p parameter_reader
  */
 void ReadOption(
-  std::shared_ptr<Aws::Client::ParameterReaderInterface> parameter_reader,
+  const std::shared_ptr<Aws::Client::ParameterReaderInterface>& parameter_reader,
   const std::string & option_key,
   const std::string & default_value,
   std::string & option_value);
@@ -166,7 +166,7 @@ void ReadOption(
  * as returned by \p parameter_reader
  */
 void ReadOption(
-  std::shared_ptr<Aws::Client::ParameterReaderInterface> parameter_reader,
+  const std::shared_ptr<Aws::Client::ParameterReaderInterface>& parameter_reader,
   const std::string & option_key,
   const size_t & default_value,
   size_t & option_value);

--- a/cloudwatch_metrics_collector/src/main.cpp
+++ b/cloudwatch_metrics_collector/src/main.cpp
@@ -42,7 +42,9 @@
 #include <cloudwatch_metrics_collector/metrics_collector_parameter_helper.hpp>
 #include <cloudwatch_metrics_common/cloudwatch_options.h>
 
-using namespace Aws::CloudWatchMetrics::Utils;
+using Aws::CloudWatchMetrics::Utils::kNodeName;
+using Aws::CloudWatchMetrics::Utils::kNodeDefaultMetricDatumStorageResolution;
+using Aws::CloudWatchMetrics::Utils::MetricsCollector;
 
 int main(int argc, char * argv[])
 {
@@ -60,9 +62,9 @@ int main(int argc, char * argv[])
   std::shared_ptr<Aws::Client::ParameterReaderInterface> parameter_reader =
           std::make_shared<Aws::Client::Ros1NodeParameterReader>();
 
-  //SDK client config
-  ClientConfigurationProvider client_config_provider(parameter_reader);
-  ClientConfiguration client_config = client_config_provider.GetClientConfiguration();
+  // SDK client config
+  Aws::Client::ClientConfigurationProvider client_config_provider(parameter_reader);
+  Aws::Client::ClientConfiguration client_config = client_config_provider.GetClientConfiguration();
 
   Aws::SDKOptions sdk_options;
 
@@ -76,12 +78,12 @@ int main(int argc, char * argv[])
   int storage_resolution = kNodeDefaultMetricDatumStorageResolution;
   Aws::CloudWatchMetrics::CloudWatchOptions cloudwatch_options;
 
-  ReadPublishFrequency(parameter_reader, publish_frequency);
-  ReadMetricNamespace(parameter_reader, metric_namespace);
-  ReadMetricDimensions(parameter_reader, dimensions_param, default_metric_dims);
-  ReadStorageResolution(parameter_reader, storage_resolution);
+  Aws::CloudWatchMetrics::Utils::ReadPublishFrequency(parameter_reader, publish_frequency);
+  Aws::CloudWatchMetrics::Utils::ReadMetricNamespace(parameter_reader, metric_namespace);
+  Aws::CloudWatchMetrics::Utils::ReadMetricDimensions(parameter_reader, dimensions_param, default_metric_dims);
+  Aws::CloudWatchMetrics::Utils::ReadStorageResolution(parameter_reader, storage_resolution);
 
-  ReadCloudWatchOptions(parameter_reader, cloudwatch_options);
+  Aws::CloudWatchMetrics::Utils::ReadCloudWatchOptions(parameter_reader, cloudwatch_options);
   //-----------------End read configuration parameters-----------------------
 
   // create the metric collector

--- a/cloudwatch_metrics_collector/src/metrics_collector.cpp
+++ b/cloudwatch_metrics_collector/src/metrics_collector.cpp
@@ -40,9 +40,6 @@
 #include <std_srvs/Empty.h>
 #include <cloudwatch_metrics_collector/metrics_collector_parameter_helper.hpp>
 
-using namespace Aws::Client;
-using namespace Aws::Utils::Logging;
-using namespace Aws::CloudWatchMetrics::Utils;
 
 namespace Aws {
 namespace CloudWatchMetrics {

--- a/cloudwatch_metrics_collector/src/metrics_collector.cpp
+++ b/cloudwatch_metrics_collector/src/metrics_collector.cpp
@@ -33,6 +33,7 @@
 #include <cloudwatch_metrics_common/metric_service.hpp>
 #include <cloudwatch_metrics_common/metric_service_factory.hpp>
 #include <string>
+#include <utility>
 #include <vector>
 #include <map>
 #include <std_srvs/Trigger.h>
@@ -50,13 +51,13 @@ namespace Utils {
 void MetricsCollector::Initialize(std::string metric_namespace,
                          std::map<std::string, std::string> & default_dimensions,
                          int storage_resolution,
-                         ros::NodeHandle node_handle,
+                         const ros::NodeHandle& node_handle,
                          const Aws::Client::ClientConfiguration & config,
                          const Aws::SDKOptions & sdk_options,
                          const Aws::CloudWatchMetrics::CloudWatchOptions & cloudwatch_options,
-                         std::shared_ptr<MetricServiceFactory> metric_service_factory) {
+                         const std::shared_ptr<MetricServiceFactory>& metric_service_factory) {
 
-  this->metric_namespace_ = metric_namespace;
+  this->metric_namespace_ = std::move(metric_namespace);
   this->default_dimensions_ = default_dimensions;
   this->storage_resolution_.store(storage_resolution);
   this->node_handle_ = node_handle;
@@ -69,9 +70,9 @@ void MetricsCollector::Initialize(std::string metric_namespace,
 void MetricsCollector::SubscribeAllTopics()
 {
   ReadTopics(topics_);
-  for (auto it = topics_.begin(); it != topics_.end(); ++it) {
+  for (auto & topic : topics_) {
     ros::Subscriber sub = node_handle_.subscribe<ros_monitoring_msgs::MetricList>(
-            *it, kNodeSubQueueSize,
+            topic, kNodeSubQueueSize,
             [this](const ros_monitoring_msgs::MetricList::ConstPtr & metric_list_msg) -> void {
                 this->RecordMetrics(metric_list_msg);
             });
@@ -90,12 +91,12 @@ int MetricsCollector::RecordMetrics(
 
     std::map<std::string, std::string> dimensions;
 
-    for (auto it = default_dimensions_.begin(); it != default_dimensions_.end(); ++it) {
-      dimensions.emplace(it->first, it->second);  // ignore the return, if we get a duplicate we're
+    for (auto & default_dimension : default_dimensions_) {
+      dimensions.emplace(default_dimension.first, default_dimension.second);  // ignore the return, if we get a duplicate we're
                                                   // going to stick with the first one
     }
-    for (auto it = metric_msg->dimensions.begin(); it != metric_msg->dimensions.end(); ++it) {
-      dimensions.emplace((*it).name, (*it).value);  // ignore the return, if we get a duplicate
+    for (const auto & dimension : metric_msg->dimensions) {
+      dimensions.emplace(dimension.name, dimension.value);  // ignore the return, if we get a duplicate
                                                     // we're going to stick with the first one
     }
     AWS_LOGSTREAM_DEBUG(__func__, "Recording metric with name=[" << metric_msg->metric_name << "]");

--- a/cloudwatch_metrics_collector/src/metrics_collector_parameter_helper.cpp
+++ b/cloudwatch_metrics_collector/src/metrics_collector_parameter_helper.cpp
@@ -37,7 +37,7 @@ namespace Utils {
  * as returned by \p parameter_reader
  */
 void ReadPublishFrequency(
-        std::shared_ptr<Aws::Client::ParameterReaderInterface> parameter_reader,
+        const std::shared_ptr<Aws::Client::ParameterReaderInterface>& parameter_reader,
         double & publish_frequency) {
 
   Aws::AwsError ret =
@@ -69,7 +69,7 @@ void ReadPublishFrequency(
  * @return
  */
 void ReadMetricNamespace(
-        std::shared_ptr<Aws::Client::ParameterReaderInterface> parameter_reader,
+        const std::shared_ptr<Aws::Client::ParameterReaderInterface>& parameter_reader,
         std::string & metric_namespace) {
 
   // Load the metric namespace
@@ -93,7 +93,7 @@ void ReadMetricNamespace(
  * @return
  */
 void ReadMetricDimensions(
-        std::shared_ptr<Aws::Client::ParameterReaderInterface> parameter_reader,
+        const std::shared_ptr<Aws::Client::ParameterReaderInterface>& parameter_reader,
         Aws::String & dimensions_param,
         std::map<std::string, std::string> & metric_dims) {
 
@@ -105,16 +105,16 @@ void ReadMetricDimensions(
   logging_stream << "Default Metric Dimensions: { ";
   if (Aws::AWS_ERR_OK == read_dimensions_status) {
     auto dims = Aws::Utils::StringUtils::Split(dimensions_param, ';');
-    for (auto it = dims.begin(); it != dims.end(); ++it) {
-      if (!it->empty()) {
-        auto dim_vec = Aws::Utils::StringUtils::Split(*it, ':');
+    for (auto & dim : dims) {
+      if (!dim.empty()) {
+        auto dim_vec = Aws::Utils::StringUtils::Split(dim, ':');
         if (dim_vec.size() == 2) {
           metric_dims.emplace(dim_vec[0].c_str(), dim_vec[1].c_str());
           logging_stream << dim_vec[0] << ": " << dim_vec[1] << ", ";
         } else {
           AWS_LOGSTREAM_WARN(
                   __func__, "Could not parse dimension: "
-                          << *it << ". Should be in the format <DimensionName>:<DimensionValue>");
+                          << dim << ". Should be in the format <DimensionName>:<DimensionValue>");
         }
       }
     }
@@ -130,7 +130,7 @@ void ReadMetricDimensions(
  * @return
  */
 void ReadStorageResolution(
-        std::shared_ptr<Aws::Client::ParameterReaderInterface> parameter_reader,
+        const std::shared_ptr<Aws::Client::ParameterReaderInterface>& parameter_reader,
         int & storage_resolution) {
 
   // Load the storage resolution
@@ -173,10 +173,10 @@ void ReadTopics(std::vector<std::string> & topics) {
 }
 
 void ReadCloudWatchOptions(
-  std::shared_ptr<Aws::Client::ParameterReaderInterface> parameter_reader,
+  const std::shared_ptr<Aws::Client::ParameterReaderInterface>& parameter_reader,
   Aws::CloudWatchMetrics::CloudWatchOptions & cloudwatch_options) {
 
-  Aws::DataFlow::UploaderOptions uploader_options;
+  Aws::DataFlow::UploaderOptions uploader_options{};
   Aws::FileManagement::FileManagerStrategyOptions file_manager_strategy_options;
 
   ReadUploaderOptions(parameter_reader, uploader_options);
@@ -189,7 +189,7 @@ void ReadCloudWatchOptions(
 }
 
 void ReadUploaderOptions(
-  std::shared_ptr<Aws::Client::ParameterReaderInterface> parameter_reader,
+  const std::shared_ptr<Aws::Client::ParameterReaderInterface>& parameter_reader,
   Aws::DataFlow::UploaderOptions & uploader_options) {
 
   ReadOption(
@@ -229,7 +229,7 @@ void ReadUploaderOptions(
 }
 
 void ReadFileManagerStrategyOptions(
-  std::shared_ptr<Aws::Client::ParameterReaderInterface> parameter_reader,
+  const std::shared_ptr<Aws::Client::ParameterReaderInterface>& parameter_reader,
   Aws::FileManagement::FileManagerStrategyOptions & file_manager_strategy_options) {
 
   ReadOption(
@@ -264,7 +264,7 @@ void ReadFileManagerStrategyOptions(
 }
 
 void ReadOption(
-  std::shared_ptr<Aws::Client::ParameterReaderInterface> parameter_reader,
+  const std::shared_ptr<Aws::Client::ParameterReaderInterface>& parameter_reader,
   const std::string & option_key,
   const std::string & default_value,
   std::string & option_value) {
@@ -286,7 +286,7 @@ void ReadOption(
 }
 
 void ReadOption(
-  std::shared_ptr<Aws::Client::ParameterReaderInterface> parameter_reader,
+  const std::shared_ptr<Aws::Client::ParameterReaderInterface>& parameter_reader,
   const std::string & option_key,
   const size_t & default_value,
   size_t & option_value) {
@@ -300,7 +300,7 @@ void ReadOption(
                          option_key << " parameter not found, setting to default value: " << default_value);
       break;
     case Aws::AwsError::AWS_ERR_OK:
-      option_value = (size_t)param_value;
+      option_value = static_cast<size_t>(param_value);
       AWS_LOGSTREAM_INFO(__func__, option_key << " is set to: " << option_value);
       break;
     default:

--- a/cloudwatch_metrics_collector/src/metrics_collector_parameter_helper.cpp
+++ b/cloudwatch_metrics_collector/src/metrics_collector_parameter_helper.cpp
@@ -22,7 +22,8 @@
 #include <cloudwatch_metrics_collector/metrics_collector_parameter_helper.hpp>
 #include <cloudwatch_metrics_common/cloudwatch_options.h>
 
-using namespace Aws::Client;
+using Aws::Client::ParameterPath;
+
 
 namespace Aws {
 namespace CloudWatchMetrics {

--- a/cloudwatch_metrics_collector/test/cloudwatch_metrics_collector_test.cpp
+++ b/cloudwatch_metrics_collector/test/cloudwatch_metrics_collector_test.cpp
@@ -27,16 +27,13 @@
 #include <ros_monitoring_msgs/MetricData.h>
 
 #include <cloudwatch_metrics_collector/metrics_collector_parameter_helper.hpp>
+#include <utility>
 
 using namespace Aws::CloudWatchMetrics;
 using namespace Aws::CloudWatchMetrics::Utils;
 using ::testing::_;
-using ::testing::AllOf;
-using ::testing::HasSubstr;
 using ::testing::Return;
 using ::testing::StrEq;
-using ::testing::Eq;
-using ::testing::InSequence;
 
 int test_argc;
 char** test_argv;
@@ -74,7 +71,7 @@ public:
     MetricServiceMock(std::shared_ptr<Publisher<MetricDatumCollection>> publisher,
                       std::shared_ptr<DataBatcher<MetricDatum>> batcher,
                       std::shared_ptr<FileUploadStreamer<MetricDatumCollection>> file_upload_streamer = nullptr)
-            : MetricService(publisher, batcher, file_upload_streamer) {}
+            : MetricService(std::move(publisher), std::move(batcher), std::move(file_upload_streamer)) {}
 
     MOCK_METHOD1(batchData, bool(const MetricObject & data_to_batch));
     MOCK_METHOD0(start, bool());
@@ -103,7 +100,7 @@ protected:
   std::shared_ptr<ros::NodeHandle> node_handle;
   std::shared_ptr<ros::Publisher> metrics_pub;
 
-  void SetUp()
+  void SetUp() override
   {
     metric_batcher = std::make_shared<MetricBatcherMock>();
     metric_publisher = std::make_shared<MetricPublisherMock>(metric_namespace, config);
@@ -141,7 +138,7 @@ protected:
     metrics_collector->start();
   }
 
-  void TearDown() {
+  void TearDown() override {
     if(metrics_collector) {
       EXPECT_CALL(*metric_service, shutdown()).Times(1);
       metrics_collector->shutdown();
@@ -359,8 +356,8 @@ TEST_F(MetricsCollectorFixture, metricRecordedWithDefaultDimensions)
 TEST_F(MetricsCollectorFixture, customTopicsListened)
 {
   std::vector<std::string> topics;
-  topics.push_back("metrics_topic0");
-  topics.push_back("metrics_topic1");
+  topics.emplace_back("metrics_topic0");
+  topics.emplace_back("metrics_topic1");
   ros::param::set(kNodeParamMonitorTopicsListKey, topics);
 
   std::map<std::string, std::string> default_metric_dims;

--- a/cloudwatch_metrics_collector/test/cloudwatch_metrics_collector_test.cpp
+++ b/cloudwatch_metrics_collector/test/cloudwatch_metrics_collector_test.cpp
@@ -31,6 +31,7 @@
 
 using namespace Aws::CloudWatchMetrics;
 using namespace Aws::CloudWatchMetrics::Utils;
+using namespace Aws::FileManagement;
 using ::testing::_;
 using ::testing::Return;
 using ::testing::StrEq;


### PR DESCRIPTION
*Description of changes:*

Fixing linting issues found by `clang-tidy` 6.0, without introducing public API changes (there may be ABI changes though).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.